### PR TITLE
Conforming to dustjs-helpers API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,23 +1,12 @@
-var moment = require('moment');
-
-module.exports = function( dust ) {
-
-    if (!dust) {
-        throw new Error('Parameter "dust" is not defined.');
-    }
-
-    dust.helpers = dust.helpers || {};
-
+(function (dust, moment) {
     dust.helpers.formatDate = function(chunk, context, bodies, params) {
-
         var date   = dust.helpers.tap(params.date,   chunk, context);
         var format = dust.helpers.tap(params.format, chunk, context);
         var lan    = dust.helpers.tap(params.lan,    chunk, context) || 'en-US';
-
         moment.lang(lan);
-
         return chunk.write(moment(date).format(format));
-
     };
-
-};
+}(
+    typeof exports !== 'undefined' ? module.exports = require('dustjs-linkedin') : dust),
+    moment ? moment : require('moment')
+);


### PR DESCRIPTION
I think it's better if all the dust helpers follow a standard convention.
Conforming to what dustjs-helpers (and all the dustmotes modules - and several other modules) does is probably the best option.
As a plus, wth this pull request the code is able to work seamlessly in the browser and in node.js.

The code used to require formatdate would simply become:

```
var dust = require('dustjs -linkedin');
dust.helpers = require('dustjs-helpers').helpers; //HACK: https://github.com/linkedin/dustjs-helpers/issues/72
require('dustjs-helper-formatdate');
require('dustmotes-provide');
require('dustmotes-substr');
require('dustmotes-if');
require('dustmotes-iterate');
```

And for the browser:

```
<script src="/js/dust.js"></script>
<script src="/js/moment.js"></script>
<script src="/js/dustjs-helper-formatdate.js"></script>
```

@adambene:
thanks for the helper and just let me know if something doesn't suit you with this pull request :)
