### PR TITLE
Bring back support for empty date and 1970-01-01

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@
         date = +date || date;
 
         moment.locale(lan);
-        return chunk.write(date ? moment(date).format(format) : '');
+        return chunk.write(moment(date).format(format));
     };
 
     if (typeof exports !== 'undefined') {


### PR DESCRIPTION
With version `0.1.0` not setting a `date` would make the helper work with the current date.
I don't see any reason for removing this functionality and returning a blank string instead.

If I'm using your helper presumably I want to format some kind of date and the default option in `moment()` is to return the current date.

Accepting only truthy values for date also creates another problem: now it's impossible to pass a timestamp for 1970-01-01.

With this pull request we'll be compatible again with 0.1.0 and we'll respect the behaviour of moment.

Cheers
